### PR TITLE
Fixing ansible install on ecs ec2 instance userdata.

### DIFF
--- a/templates/jfrog-artifactory-ecs-ec2.template.yaml
+++ b/templates/jfrog-artifactory-ecs-ec2.template.yaml
@@ -363,7 +363,7 @@ Resources:
 
             pip install awscli &> /var/log/userdata.awscli_install.log || qs_err " awscli install failed "
 
-            pip install ansible &> /var/log/userdata.ansible_install.log || qs_err " ansible install failed "
+            pip3 install ansible &> /var/log/userdata.ansible_install.log || qs_err " ansible install failed "
 
             pip install selinux &> /var/log/userdata.selinux_install.log || qs_err " selinux install failed "
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The command fails when using pip (python2) due to unicode issues in the install. Works fine with pip3 (python3). This pip install is a system level tool and not a python package, so there are no concerns with using a different python version. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
