### PR TITLE
Update binarystore.xml.j2

### DIFF
--- a/scripts/roles/artifactory/templates/binarystore.xml.j2
+++ b/scripts/roles/artifactory/templates/binarystore.xml.j2
@@ -1,7 +1,7 @@
 {% if artifactory_major_verion|int == 7 %}
 <!-- AWS S3 V3 -->
 <config version="2">
-    <chain> <!--template="cluster-s3-storage-v3"-->
+    <chain template="cluster-s3-storage-v3">
         <provider id="cache-fs-eventual-s3" type="cache-fs">
             <provider id="sharding-cluster-eventual-s3" type="sharding-cluster">
                 <sub-provider id="eventual-cluster-s3" type="eventual-cluster">


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Updated chain header per conversation with jfrog support.  Having this commented out is causing caching on the /data mount to fill and crash the node.  By making this change files will correctly cache in S3.  Further info can be found at the following link:

https://www.jfrog.com/confluence/display/JFROG/Configuring+the+Filestore#ConfiguringtheFilestore-AmazonS3SDKClusterBinaryProvider


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
